### PR TITLE
translation : misprint 	

### DIFF
--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -46,7 +46,7 @@ flarum-tags:
 
     # These translations are used in the Tags page.
     tags:
-      about_tags_text: "Les étiquettes permettent de catégoriser les discussions. Les étiquettes primaires sont similaires aux traditionnelles catégories, elles peuvent être disposées en une hiérarchie à deux niveaux. Les étiquettes secondaires ne sont ni hierarchisées, ni ordonnées, mais peuvent êtres utilisées comme des catégories mineures."
+      about_tags_text: "Les étiquettes permettent de catégoriser les discussions. Les étiquettes primaires sont similaires aux traditionnelles catégories, elles peuvent être disposées en une hiérarchie à deux niveaux. Les étiquettes secondaires ne sont ni hierarchisées, ni ordonnées, mais peuvent être utilisées comme des catégories mineures."
       create_tag_button: => flarum-tags.ref.create_tag
       primary_heading: Étiquettes primaires
       secondary_heading: Étiquettes secondaires


### PR DESCRIPTION
misprint : "être" instead of "êtres" in "mais peuvent être utilisées comme des catégories mineures".
