### PR TITLE
Add french translation for extension fof-userbio

### DIFF
--- a/locale/fof-userbio.yml
+++ b/locale/fof-userbio.yml
@@ -1,0 +1,3 @@
+fof-userbio:
+  forum:
+    userbioPlaceholder: Ecrivez quelque chose à propos de vous


### PR DESCRIPTION
The french translation is missing for fof-userbio is missing

### Description

The FriendsOfFlarum team doesn't accept translations for their extensions.
They ask to go through the language packs

### Additional information

If you accept this one, I want to do the same for others FriendsOfFlarum extensions

Thanks & Regards